### PR TITLE
Fixed atomicity of bulk upload transactions

### DIFF
--- a/metpetdb_api/api/bulk_upload/v1/tests.py
+++ b/metpetdb_api/api/bulk_upload/v1/tests.py
@@ -1,6 +1,6 @@
 import json
 from rest_framework import status
-from rest_framework.test import APIClient, APITestCase
+from rest_framework.test import APIClient, APITransactionTestCase
 
 from apps.users.models import User
 
@@ -17,7 +17,7 @@ from apps.chemical_analyses.models import(
     Oxide,
 )
 
-class BulkUploadTests(APITestCase):
+class BulkUploadTests(APITransactionTestCase):
     """
     Bulk upload error classes are documented in the wiki: 
     https://github.com/metpetdb/api_v2/wiki/Bulk-Upload


### PR DESCRIPTION
While reading up on atomic transactions in Django, I realized that the caught errors in bulk upload were not breaking the transactions. Catching exceptions within an atomic decorator will still result in a commit to the DB. This has been fixed by manually specifying the start and end of each transaction with auto_commit disabled.